### PR TITLE
Fix kerning bug for nina tile on Safari mobile

### DIFF
--- a/src/tile-nina/tile-nina.scss
+++ b/src/tile-nina/tile-nina.scss
@@ -1,3 +1,4 @@
+@import '~polaris-global/globals/fonts';
 @import '~polaris-global/globals/colours';
 @import '~polaris-global/globals/responsive';
 
@@ -32,7 +33,7 @@
   }
 
   .tile-nina-button {
-    font-weight: bold;
+    @include font($skytext-med);
     margin: 10% auto 0;
     display: inline-block;
     padding: .5em 1em;


### PR DESCRIPTION
http://jira-psp.cg.bskyb.com/browse/LOFOI-616

Seems to be a reasonably well known bug within mobile safari that renders faux styles incorrectly; http://stackoverflow.com/a/11879044. This occurs when a font-style of bold is used on a TTF that does not have a bold style. Instead of defining a weight of bold, use the medium font that is present on the page.

Tested in BrowserStack Local and seems okay!
