### PR TITLE
Add text-with-transparent-background theme

### DIFF
--- a/demo/styles/panel.css
+++ b/demo/styles/panel.css
@@ -45,8 +45,7 @@
   line-height: 100vh;
   position: relative;
   width: 100%; }
-  .panel-inner:after,
-  .panel-inner:before {
+  .panel-inner:after, .panel-inner:before {
     content: '';
     height: 10px;
     left: 0;

--- a/demo/styles/tile.css
+++ b/demo/styles/tile.css
@@ -440,14 +440,10 @@
 /*
 *  #responsive-mixins
 */
-.tile.type-channel:hover .tile-inner .tile-bg-active,
-.tile.type-channel:focus .tile-inner .tile-bg-active,
-.tile.type-channel.has-focus .tile-inner .tile-bg-active {
+.tile.type-channel:hover .tile-inner .tile-bg-active, .tile.type-channel:focus .tile-inner .tile-bg-active, .tile.type-channel.has-focus .tile-inner .tile-bg-active {
   opacity: 1; }
 
-.tile.type-channel:hover .tile-title,
-.tile.type-channel:focus .tile-title,
-.tile.type-channel.has-focus .tile-title {
+.tile.type-channel:hover .tile-title, .tile.type-channel:focus .tile-title, .tile.type-channel.has-focus .tile-title {
   color: white; }
 
 .tile.type-channel .tile-content {
@@ -697,19 +693,13 @@
   .tile-sponsor:hover .sponsor-label {
     text-decoration: underline; }
 
-.tile.type-content:hover .tile-inner .tile-bg-active,
-.tile.type-content:focus .tile-inner .tile-bg-active,
-.tile.type-content.has-focus .tile-inner .tile-bg-active {
+.tile.type-content:hover .tile-inner .tile-bg-active, .tile.type-content:focus .tile-inner .tile-bg-active, .tile.type-content.has-focus .tile-inner .tile-bg-active {
   opacity: 1; }
 
-.tile.type-content:hover .tile-title,
-.tile.type-content:focus .tile-title,
-.tile.type-content.has-focus .tile-title {
+.tile.type-content:hover .tile-title, .tile.type-content:focus .tile-title, .tile.type-content.has-focus .tile-title {
   color: white; }
 
-.tile.type-content:hover .tile-sponsor span,
-.tile.type-content:focus .tile-sponsor span,
-.tile.type-content.has-focus .tile-sponsor span {
+.tile.type-content:hover .tile-sponsor span, .tile.type-content:focus .tile-sponsor span, .tile.type-content.has-focus .tile-sponsor span {
   color: white; }
 
 .tile.type-content .tile-bg {
@@ -727,14 +717,12 @@
     background-size: 100%; }
 
 @media (min-width: 641px) and (max-width: 1024px) {
-  .tile.type-content.small .tile-media-logo-channel,
-  .tile.type-content.medium .tile-media-logo-channel {
+  .tile.type-content.small .tile-media-logo-channel, .tile.type-content.medium .tile-media-logo-channel {
     left: 1.5vw;
     bottom: 1.5vw; } }
 
 @media (max-width: 640px) {
-  .tile.type-content.small .tile-media-logo-channel,
-  .tile.type-content.medium .tile-media-logo-channel {
+  .tile.type-content.small .tile-media-logo-channel, .tile.type-content.medium .tile-media-logo-channel {
     bottom: 3vw;
     left: 3vw; } }
 
@@ -756,8 +744,7 @@
   left: 1.5vw;
   position: absolute;
   width: 200px; }
-  .tile.type-content .tile-media-logo-channel[src*=sky-box-sets],
-  .tile.type-content .tile-media-logo-channel[src*=Sky-Store] {
+  .tile.type-content .tile-media-logo-channel[src*=sky-box-sets], .tile.type-content .tile-media-logo-channel[src*=Sky-Store] {
     height: 12.5%;
     max-height: 30px;
     min-height: 25px; }
@@ -914,8 +901,7 @@
 .tile.type-link .tile-media {
   padding-bottom: 100%; }
 
-.tile.type-link.small .tile-content-inner,
-.tile.type-link.medium .tile-content-inner {
+.tile.type-link.small .tile-content-inner, .tile.type-link.medium .tile-content-inner {
   bottom: auto; }
 
 .tile.type-link.theme-light .tile-title {
@@ -924,27 +910,22 @@
 .tile.type-link.theme-dark .tile-title {
   color: white; }
 
-.tile.type-link.theme-light .tile-content-inner,
-.tile.type-link.theme-dark .tile-content-inner {
+.tile.type-link.theme-light .tile-content-inner, .tile.type-link.theme-dark .tile-content-inner {
   bottom: 0; }
 
-.tile.type-link.theme-light.small .tile-content-inner,
-.tile.type-link.theme-dark.small .tile-content-inner {
+.tile.type-link.theme-light.small .tile-content-inner, .tile.type-link.theme-dark.small .tile-content-inner {
   top: 1vw; }
 
-.tile.type-link.theme-light.medium .tile-content-inner,
-.tile.type-link.theme-dark.medium .tile-content-inner {
+.tile.type-link.theme-light.medium .tile-content-inner, .tile.type-link.theme-dark.medium .tile-content-inner {
   top: 1.25vw; }
 
-.tile.type-link.theme-light .tile-content,
-.tile.type-link.theme-dark .tile-content {
+.tile.type-link.theme-light .tile-content, .tile.type-link.theme-dark .tile-content {
   position: absolute;
   width: 100%;
   bottom: 0;
   padding-bottom: 43.75%; }
 
-.tile.type-link.theme-light .tile-title,
-.tile.type-link.theme-dark .tile-title {
+.tile.type-link.theme-light .tile-title, .tile.type-link.theme-dark .tile-title {
   position: absolute;
   top: 50%;
   transform: translateY(-50%); }
@@ -991,7 +972,7 @@
   font-weight: normal;
   margin: 10% auto 0;
   display: inline-block;
-  padding: 0.5em 1em;
+  padding: .5em 1em;
   border: 2px solid #0073c5;
   border-radius: 4px;
   color: #0073c5;
@@ -1144,8 +1125,7 @@
   bottom: 2vw;
   left: 1.5vw; }
 
-.tile.theme-text-with-background.small .tile-legal,
-.tile.theme-text-with-background.medium .tile-legal {
+.tile.theme-text-with-background.small .tile-legal, .tile.theme-text-with-background.medium .tile-legal {
   position: absolute;
   color: #222222;
   font-size: 13px;
@@ -1153,11 +1133,9 @@
   font-family: SkyTextRegular, Helvetica, Arial, Sans-Serif;
   font-weight: normal; }
   @media (min-width: 641px) and (max-width: 1024px) {
-    .tile.theme-text-with-background.small .tile-legal,
-    .tile.theme-text-with-background.medium .tile-legal {
+    .tile.theme-text-with-background.small .tile-legal, .tile.theme-text-with-background.medium .tile-legal {
       bottom: 2vw; } }
   @media (max-width: 640px) {
-    .tile.theme-text-with-background.small .tile-legal,
-    .tile.theme-text-with-background.medium .tile-legal {
+    .tile.theme-text-with-background.small .tile-legal, .tile.theme-text-with-background.medium .tile-legal {
       left: 3vw;
       bottom: 4vw; } }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiles",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Initial styles for polaris tiles. Not intended for use long term",
   "repository": {
     "type": "git",

--- a/src/tile-link/_tile-link-with-transparent-background.scss
+++ b/src/tile-link/_tile-link-with-transparent-background.scss
@@ -1,0 +1,81 @@
+@import '~polaris-global/globals/colours';
+@import '~polaris-global/globals/fonts';
+@import '~polaris-global/globals/mixins';
+@import '~polaris-global/globals/responsive';
+
+@import '../globals/constants';
+
+@function desktop-font($multiplier) {
+  @return ($multiplier / $desktop) * 100vw;
+}
+
+.tile.theme-text-with-transparent-background {
+
+  .tile-media {
+    padding-bottom: 62.25%;
+  }
+
+  .tile-content {
+    padding-bottom: 37.75%;
+  }
+
+  .tile-content-inner {
+    text-align: center;
+  }
+
+  .tile-title {
+    line-height: 4vw;
+    padding: 0 3.3vw;
+  }
+
+  .tile-title,
+  .tile-link:hover .tile-title {
+    color: $dark-grey;
+  }
+
+  &.small,
+  &.medium {
+    .tile-content-inner {
+      bottom: 1.25vw;
+    }
+  }
+
+  &.medium {
+    .tile-title {
+      font-size: desktop-font(41);
+    }
+  }
+
+  .tile-bg {
+    position: absolute;
+    top: 0%;
+    right: 0;
+    bottom: -1px;
+    left: 0;
+
+    > div {
+      position: absolute;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
+      background-size: 100%;
+    }
+   }
+
+  .tile-bg-default {
+    @extend .polaris-bg-default;
+  }
+
+  .tile-bg-active {
+    @include transition(opacity $med-transition ease);
+    opacity: 0;
+    @extend .polaris-bg-default-dark;
+  }
+
+  &:hover {
+    .tile-bg-active {
+      opacity: 1;
+    }
+  }
+}


### PR DESCRIPTION
This PR adds a theme required for the my account page. The theme extends tile-link. Works together with https://github.com/sky-uk/sky-pages/pull/966. 

![screen shot 2016-05-06 at 11 55 02](https://cloud.githubusercontent.com/assets/7579449/15073615/7a9de1fa-1392-11e6-85a1-d9f9f6e96ff6.png)
