### PR TITLE
We no longer pull in the fonts from the masthead in sky-pages making …

### DIFF
--- a/src/tile-link/_tile-link-with-background.scss
+++ b/src/tile-link/_tile-link-with-background.scss
@@ -74,7 +74,6 @@
       color: $dark-grey;
       font-size: 13px;
       line-height: 1em;
-      @include font($skytext-reg);
 
       @include tablet {
         bottom: $tile-content-tablet-vertical-spacing;

--- a/src/tile-nina/tile-nina.scss
+++ b/src/tile-nina/tile-nina.scss
@@ -33,7 +33,6 @@
   }
 
   .tile-nina-button {
-    @include font($skytext-med);
     margin: 10% auto 0;
     display: inline-block;
     padding: .5em 1em;

--- a/src/tile/_tile.scss
+++ b/src/tile/_tile.scss
@@ -113,7 +113,6 @@
   margin: 0;
   line-height: 1em;
   color: $white;
-  @include font($skytext-reg);
 
   .tile:hover & {
     text-decoration: underline;
@@ -144,7 +143,6 @@
   margin: 0;
   line-height: 1em;
   color: $white;
-  @include font($skytext-reg);
 
   .tile.small & {
     font-size: 20 / $desktop * 100vw;


### PR DESCRIPTION
…the font declarations for SkyTextRegular defunct, just inherit from Toolkit
